### PR TITLE
Add missing broccoli-coffee dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/kristianmandrup/ember-cli-emberscript",
   "dependencies": {
+    "broccoli-coffee": "^0.3.0",
     "fs-extra": "^0.11.0",
     "inflection": "^1.4.0",
     "broccoli-ember-script": "git://github.com/kristianmandrup/broccoli-ember-script#master",


### PR DESCRIPTION
Not sure if I configured something wrong in my Ember CLI project, but when I added `ember-cli-embercript` as a dependency, everything started complaining about `Cannot find module 'broccoli-coffee'`. Adding that as a dependency to `ember-cli-emberscript` seems to help.
